### PR TITLE
Add reCAPTCHA validation to contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_RECAPTCHA_SITE_KEY=your_site_key_here
+RECAPTCHA_SECRET_KEY=your_secret_key_here

--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ Experiencia laboral.
 Mis conocmientos y niveles de estudios alcanzados.
 Medios de conectato.
 Te invito a que lo puedas ver o visitar a la siguiente dirección: www.danielalbertorosso.com.ar
+
+## reCAPTCHA
+
+Para evitar el spam en el formulario de contacto se integró Google reCAPTCHA. Para que funcione es necesario definir dos variables de entorno:
+
+```
+VITE_RECAPTCHA_SITE_KEY=<tu_clave_del_sitio>
+RECAPTCHA_SECRET_KEY=<tu_clave_secreta>
+```
+
+Estas variables se pueden configurar creando un archivo `.env` en la raíz del proyecto (ver `.env.example`).

--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com" rel="stylesheet" media="print" onload="this.media='all'"></script>
 
+    <!-- Google reCAPTCHA -->
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
     <!-- Script principal -->
     <script type="module" src="/src/main.tsx"></script>
 

--- a/public/send_email.php
+++ b/public/send_email.php
@@ -5,6 +5,22 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $last_name  = htmlspecialchars($_POST['last_name']);
     $email      = htmlspecialchars($_POST['email']);
     $message    = htmlspecialchars($_POST['message']);
+    $token      = $_POST['token'] ?? '';
+
+    // Verificar el token de reCAPTCHA
+    $secret = getenv('RECAPTCHA_SECRET_KEY');
+    if (!$secret || !$token) {
+        http_response_code(400);
+        echo json_encode(["status" => "error", "message" => "Token de seguridad inválido."]);
+        exit;
+    }
+    $verifyResponse = file_get_contents("https://www.google.com/recaptcha/api/siteverify?secret=" . urlencode($secret) . "&response=" . urlencode($token));
+    $captchaData = json_decode($verifyResponse, true);
+    if (!isset($captchaData['success']) || !$captchaData['success']) {
+        http_response_code(400);
+        echo json_encode(["status" => "error", "message" => "Fallo la verificación reCAPTCHA."]);
+        exit;
+    }
 
     $to = "danielalbertorosso@gmail.com";
     $subject = "Este es el nuevo mensaje de contacto desde la pagina personal";

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -12,11 +12,17 @@ const ContactPage = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const token = (window as any).grecaptcha?.getResponse() as string;
+    if (!token) {
+      setResponseMessage('Por favor verifica que no eres un robot.');
+      return;
+    }
     const formData = new FormData();
     formData.append('first_name', firstName);
     formData.append('last_name', lastName);
     formData.append('email', email);
     formData.append('message', message);
+    formData.append('token', token);
 
     try {
       const response = await fetch('send_email.php', {
@@ -29,6 +35,7 @@ const ContactPage = () => {
       } else {
         setResponseMessage('Error al enviar el mensaje: ' + data.message);
       }
+      (window as any).grecaptcha?.reset();
     } catch (error) {
       setResponseMessage('Error al enviar el mensaje.');
     }
@@ -86,13 +93,19 @@ const ContactPage = () => {
             <label htmlFor="message" className="block text-gray-700 text-sm font-bold mb-2">
               {t("contact_form_description")}
             </label>
-            <textarea
-              id="message"
-              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-              rows={5}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-            ></textarea>
+          <textarea
+            id="message"
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            rows={5}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          ></textarea>
+          </div>
+          <div className="mb-6">
+            <div
+              className="g-recaptcha"
+              data-sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
+            ></div>
           </div>
           <div className="flex items-center justify-between">
             <button

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_RECAPTCHA_SITE_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- load reCAPTCHA on the page
- validate reCAPTCHA token client-side and server-side
- document the new environment variables
- provide `.env.example` with placeholders

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d7e8b80dc832baadcd5666f2450d9